### PR TITLE
Update docker dependency

### DIFF
--- a/.github/workflows/pr-all-services.yml
+++ b/.github/workflows/pr-all-services.yml
@@ -34,7 +34,7 @@ jobs:
       # This block should eventually become use lando/actions-hyperdrive@v2
       - name: Verify Docker dependencies
         run: |
-          docker --version | grep "20.10."
+          docker --version | grep "23.0."
           docker-compose --version | grep "1.29."
       - name: Grab latest edge Lando CLI
         run: |

--- a/.github/workflows/pr-drupal9-base.yml
+++ b/.github/workflows/pr-drupal9-base.yml
@@ -34,7 +34,7 @@ jobs:
       # This block should eventually become use lando/actions-hyperdrive@v2
       - name: Verify Docker dependencies
         run: |
-          docker --version | grep "20.10."
+          docker --version | grep "23.0."
           docker-compose --version | grep "1.29."
       - name: Grab latest edge Lando CLI
         run: |


### PR DESCRIPTION
Updates the docker step in Verify Docker dependencies from `20.10.` to `23.0.` - https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230728.3